### PR TITLE
Add float for checkboxes & radiobuttons

### DIFF
--- a/styles/settings/inputs.less
+++ b/styles/settings/inputs.less
@@ -40,6 +40,7 @@
         }
     }
     .radio, .checkbox {
+        float: left;
         padding-left: 3rem;
 
         .setting-description {


### PR DESCRIPTION
There's a glitch on the settings page without the adding the float.

**Before**:

![before](https://cloud.githubusercontent.com/assets/1504938/14911345/1eae0912-0df5-11e6-8d6c-7a05d54aec73.png)

**After**:

![after](https://cloud.githubusercontent.com/assets/1504938/14911349/219b1002-0df5-11e6-8a77-130a4d463f0c.png)
