### PR TITLE
Too general selector removed from rule

### DIFF
--- a/styles/text.less
+++ b/styles/text.less
@@ -39,21 +39,23 @@
     font-size: 0.65rem;
 }
 // Highlights
-[class*="highlight"] {
-    font-weight: 600;
-}
 .highlight {
     color: @base-color;
+    font-weight: 600;
 }
 .highlight-info {
     color: @md-blue;
+    font-weight: 600;
 }
 .highlight-success {
     color: @md-light-green;
+    font-weight: 600;
 }
 .highlight-warning {
     color: @md-amber;
+    font-weight: 600;
 }
 .highlight-error {
     color: @md-red;
+    font-weight: 600;
 }


### PR DESCRIPTION
This rule selector applies bold font to **any** element using the "highlight" word in its classes, causing visualization problems. E.g. the atom-trailing-spaces package.