### PR TITLE
Remove tooltip max-width limit

### DIFF
--- a/styles/tooltips.less
+++ b/styles/tooltips.less
@@ -18,7 +18,7 @@
         border-radius: @component-border-radius;
         background-color: @tip-background-color;
         color: @tip-text-color;
-        max-width: 20rem;
+        max-width: none;
         word-wrap: break-word;
         word-break: keep-all;
 


### PR DESCRIPTION
Fixes #315 

I referenced a theme that didn't suffer from this issue to see how the tooltips were styled. [atom/one-dark-ui's `.tooltip` style](https://github.com/atom/one-dark-ui/blob/v1.6.0/styles/tooltips.less#L17) does not set a max-width on its tooltips. Thoughts on going with this approach? It looks to fix this issue, but I'm not sure if it has other implications.

### Before

<img width="1280" alt="typescript-tooltip-before" src="https://cloud.githubusercontent.com/assets/2344137/18190616/11911cb0-7092-11e6-80ed-df6c66ba369d.png">

### After

<img width="1280" alt="typescript-tooltip-after" src="https://cloud.githubusercontent.com/assets/2344137/18190615/1190cd32-7092-11e6-8610-2128ac2a2161.png">
