### PR TITLE
Force font-size of small tag to be 80% in markdown-preview.

### DIFF
--- a/styles/markdown-preview.less
+++ b/styles/markdown-preview.less
@@ -24,4 +24,8 @@
             background-color: lighten(@app-background-color, 8%);
         }
     }
+
+    small {
+        font-size: 80%;
+    }
 }


### PR DESCRIPTION
I had reported a bug #340 about incorrect style in [markdown-preview](https://github.com/atom/markdown-preview).

**Screenshots**

![2016-11-02 1 28 59](https://cloud.githubusercontent.com/assets/4302689/19917741/e03ac19e-a100-11e6-9488-d93601c4ad82.png)    
^ error style with atom-material-ui theme

![2016-11-10 2 18 12](https://cloud.githubusercontent.com/assets/4302689/20166562/9660c748-a750-11e6-8609-a68dbfdcc3ec.png)    
^ forcing font-size to be 80%

With unknown reason, the font-size of small tag in markdown-preview is set to 125%. This PR forces it to be 80%. 