### PR TITLE
Tweak find-and-replace selector for upcoming markup change

### DIFF
--- a/styles/panes.less
+++ b/styles/panes.less
@@ -54,7 +54,7 @@ atom-pane-resize-handle {
 .results-view {
     color: @text-color;
 
-    > li.selected::before {
+    li.path.selected::before {
         background: fade(@text-color, 20%);
         min-height: 2.5rem;
     }


### PR DESCRIPTION
As part of removing the use of jQuery from the find-and-replace package, we're having to restructure the DOM slightly. The `results-view` class now lives on a `div` that wraps the `ol` containing the search paths, so the immediate selector `.results-view > li.selected` will no longer match anything.

Refs https://github.com/atom/find-and-replace/pull/838