### PR TITLE
Add support for the activate-power-mode package.

### DIFF
--- a/styles/packages/activate-power-mode.less
+++ b/styles/packages/activate-power-mode.less
@@ -1,0 +1,37 @@
+.streak-container {
+    .title {
+        text-shadow: 2px 2px 2px @base-color;
+    }
+
+    .counter,
+    .exclamations,
+    .max {
+        color: @base-color;
+    }
+
+    .bar {
+        background: @base-color;
+    }
+
+    .generate-levels(5);
+}
+
+.generate-levels(@i) when (@i > 0) {
+    @levelColor: spin(@base-color, (@i * -10));
+    &.level-@{i} {
+        .title {
+            text-shadow: 2px 2px 2px @levelColor;
+        }
+
+        .counter,
+        .exclamations,
+        .max {
+            color: @levelColor;
+        }
+
+        .bar {
+            background: @levelColor;
+        }
+    }
+    .generate-levels(@i - 1);
+}

--- a/styles/packages/main.less
+++ b/styles/packages/main.less
@@ -1,3 +1,4 @@
+@import "activate-power-mode";
 @import "busy-signal";
 @import "linter";
 @import "nuclide";


### PR DESCRIPTION
### Description of the Change
It makes the combo counter from the [activate-power-mode](https://github.com/JoelBesada/activate-power-mode) package gets the color from this theme.

The original combo looks like this:
![screenshot from 2017-10-01 04-38-42](https://user-images.githubusercontent.com/10590799/31053486-e2b149e8-a663-11e7-95e8-de4d317c9351.png)
with a fixed green color, and while getting a higher level it changes the color.

With this change the combo now looks depending on the selected color:
![screenshot from 2017-10-01 04-38-57](https://user-images.githubusercontent.com/10590799/31053494-21f416da-a664-11e7-9445-77ebddd42e8b.png)
and the color change for higher levels is more subtle.


