### PR TITLE
Preserve colour of tab-icons

### DIFF
--- a/styles/tabs.less
+++ b/styles/tabs.less
@@ -186,11 +186,16 @@
 }
 
 // File icons
-atom-pane .tab-bar .tab .title[data-path]::before {
-    margin-right: @component-icon-padding;
-    color: @text-color !important;
+atom-pane .tab-bar .tab .title[data-path] {
+    &::before {
+        margin-right: @component-icon-padding;
+    }
 
-    .amu-tinted-tab-bar & {
-        color: @accent-text-color !important;
+    &:not(.status-modified):not(.status-added):not(.status-ignored):not(.status-removed):not(.status-renamed)::before {
+        color: @text-color !important;
+
+        .amu-tinted-tab-bar & {
+            color: @accent-text-color !important;
+        }
     }
 }

--- a/styles/tabs.less
+++ b/styles/tabs.less
@@ -191,7 +191,7 @@ atom-pane .tab-bar .tab .title[data-path] {
         margin-right: @component-icon-padding;
     }
 
-    &:not(.status-modified):not(.status-added):not(.status-ignored):not(.status-removed):not(.status-renamed)::before {
+    body:not(.file-icons-coloured) &:not(.status-modified):not(.status-added):not(.status-ignored):not(.status-removed):not(.status-renamed)::before {
         color: @text-color !important;
 
         .amu-tinted-tab-bar & {


### PR DESCRIPTION
### Description of the Change

This theme [currently overrides](https://github.com/atom-material/atom-material-ui/blob/09d4be0e6da341f35cecc730b412d741dfa2cc80/styles/tabs.less#L188) the colour of tab-icons to make them more visible when viewed against a tinted background. As @silvestreh [explains](https://github.com/atom-material/atom-material-ui/issues/349#issuecomment-279673250), *"if you have a green icon with a green background you wouldn't see it."*

Although well-intentioned, this solution breaks two user expectations:

* __The `enableVcsColoring` setting of the core `tabs` package is ignored.__
It's likely (and logical) that a tab's icon share the colour applied to its label. When VCS-aware tabs are enabled, the label's colour is rendered in orange or green for changed and added files, respectively. However, icons are singled out, making it look very inconsistent:
	<img src="https://user-images.githubusercontent.com/17392251/31058649-163d0318-a6c5-11e7-9c30-ade6fee82c76.png" width="472" alt="Figure 1" />
* __The `file-icons` package can't display coloured tab-icons.__
This is difficult to fix with user stylesheets, because `file-icons` uses many different CSS classes to apply colour. The solution is essentially copy+pasting the [package's colour classes](https://github.com/file-icons/atom/blob/5e025c2614d88405dbe206a32d4e51c8c4c3986e/styles/colours.less#L97-L131) *en masse* and affixing `!important;` to each property. Needless to say, that's neither elegant, practical, or future-proof:
	~~~less
	@import "packages/file-icons/styles/colours";

	// Copy-pasted from above stylesheet, with !important appended.
	.light-red:before     { color: @light-red !important; }
	.medium-red:before    { color: @medium-red !important; } // … etc
	~~~
	Yet the opposite is trivial to achieve:
	~~~less
	// Show uncoloured icons in the tab-bar pane only
	.tab-bar .tab .title.icon::before{
		color: inherit; // Note there's no need to include an !important flag
	}
	~~~

### Caveats / Possible Drawbacks

* ce3ea0c will only take effect once file-icons/atom@1dfac6c lands in the package's next release. Once this is merged, I'll get one cut within a few days.
* Some users may prefer the existing behaviour. It can be easily restored using the above snippet, though.

### Applicable Issues

* Fixes [`file-icons/atom#652`](https://github.com/file-icons/atom/issues/652)
* Fixes [`atom-material/atom-material-ui#438`](https://github.com/atom-material/atom-material-ui/issues/438)
* Fixes [`atom-material/atom-material-ui#349`](https://github.com/atom-material/atom-material-ui/issues/349)