### PR TITLE
Fix highlight-* colors

### DIFF
--- a/styles/text.less
+++ b/styles/text.less
@@ -101,10 +101,10 @@ code {
 
 .highlight-color(@name, @color, @text-color) {
     .highlight-@{name} {
-        color: lighten(saturate(@text-color, 0%), 30%);
+        color: lighten(saturate(@text-color, 0%), 60%);
         font-weight: bold;
         text-shadow: none;
-        background-color: fadeout(@color, 60%);
+        background-color: fadeout(@color, 30%);
         border-radius: @component-border-radius;
         padding: 1px 3px;
     }


### PR DESCRIPTION
While using this theme with a light syntax I noticed that some text (the highlights) in the Timecop panel was difficult to read (specially the green and yellow ones). 

![screenshot from 2017-10-05 20-41-28](https://user-images.githubusercontent.com/10590799/31259844-a7977b20-aa0f-11e7-82e3-680c2273540d.png)

### Description of the Change
This PR lower the fadeout of the background and increase the lighten in the text color for better contrast in them.
So it now looks like this:
![screenshot from 2017-10-05 20-46-25](https://user-images.githubusercontent.com/10590799/31259850-b2ea9b38-aa0f-11e7-9acf-4a5964f51daa.png)

### Benefits
The highlights can be read easily.