### PR TITLE
Add option to stretch tabs to full tab width

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -15,6 +15,7 @@ const classNames = {
     'amu-compact-tab-bar': atom.config.get('atom-material-ui.tabs.compactTabs'),
     'amu-no-tab-min-width': atom.config.get('atom-material-ui.tabs.noTabMinWidth'),
     'amu-tinted-tab-bar': atom.config.get('atom-material-ui.tabs.tintedTabBar'),
+    'amu-stretched-tabs': atom.config.get('atom-material-ui.tabs.stretchedTabs'),
 
     // General UI settings
     'amu-use-animations': atom.config.get('atom-material-ui.ui.useAnimations'),

--- a/lib/tab-bar/index.js
+++ b/lib/tab-bar/index.js
@@ -13,3 +13,7 @@ atom.config.observe('atom-material-ui.tabs.compactTabs', (value) => {
 atom.config.observe('atom-material-ui.tabs.noTabMinWidth', (value) => {
     toggleClassName('amu-no-tab-min-width', value);
 });
+
+atom.config.observe('atom-material-ui.tabs.stretchedTabs', (value) => {
+    toggleClassName('amu-stretched-tabs', value);
+});

--- a/package.json
+++ b/package.json
@@ -131,6 +131,12 @@
           "description": "Prevents tabs from overflowing off the tab bar.",
           "type": "boolean",
           "default": false
+        },
+        "stretchedTabs": {
+          "title": "Stretched tabs",
+          "description": "Stretch tabs to full available width of the tab bar.",
+          "type": "boolean",
+          "default": false
         }
       }
     },

--- a/styles/tabs.less
+++ b/styles/tabs.less
@@ -165,6 +165,18 @@
             }
         }
     }
+
+    .amu-stretched-tabs & {
+        // Make the tabs span the whole tab bar width
+        .tab {
+            max-width: 100%;
+            flex-grow: 2;
+            text-align: center;
+            &[data-type="TreeView"] {
+                text-align: left;
+            }
+        }
+    }
 }
 
 // Panel Shadows


### PR DESCRIPTION
### Description of the Change

Adds an option to make the tabs stretch to full available width of the tab bar. This follows what the One Dark theme does, for example.

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion.

-->

### Benefits

- Visual pleasure 😍

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

- None - the change is configurable and off by default

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues

Closes #445.

<!-- Enter any applicable Issues here -->

![tabs-full-width](https://user-images.githubusercontent.com/3058150/31436973-f6d2dffe-ae83-11e7-9646-22b10b47e68d.png)