### PR TITLE
add a `vim-mode-plus` modal cursor color override

### DIFF
--- a/styles/packages/main.less
+++ b/styles/packages/main.less
@@ -6,3 +6,4 @@
 @import "remote-ftp";
 @import "terminal";
 @import "tool-bar";
+@import "vim-mode-plus";

--- a/styles/packages/vim-mode-plus.less
+++ b/styles/packages/vim-mode-plus.less
@@ -1,0 +1,62 @@
+atom-text-editor.vim-mode-plus.normal-mode,
+atom-text-editor.vim-mode-plus.visual-mode,
+atom-text-editor.vim-mode-plus.operator-pending-mode,
+atom-text-editor.vim-mode-plus.insert-mode.replace {
+    .amu-paint-cursor & {
+        &.is-focused,
+        &.vim-mode-plus-input-focused,
+        &.vim-mode-plus-search-input-focused {
+            .cursor {
+                background-color: @base-color; // block-cursor
+            }
+        }
+    }
+}
+
+atom-text-editor.vim-mode-plus.operator-pending-mode {
+    .amu-paint-cursor & {
+        &.is-focused,
+        &.vim-mode-plus-search-input-focused {
+            .cursor {
+                background: none;
+                border-bottom-color: @base-color;
+            }
+        }
+    }
+}
+
+atom-text-editor.vim-mode-plus.insert-mode.replace {
+    .amu-paint-cursor & {
+        &.is-focused {
+            .cursor {
+                background: none;
+                border-bottom-color: @base-color;
+            }
+        }
+    }
+}
+
+// vim-mode-plus-input-focused for surround, f, F, t, T, r etc.
+atom-text-editor.vim-mode-plus.normal-mode,
+atom-text-editor.vim-mode-plus.visual-mode,
+atom-text-editor.vim-mode-plus.operator-pending-mode, {
+    .amu-paint-cursor & {
+        &.vim-mode-plus-input-focused {
+            .cursor {
+                background: none;
+                border-bottom-color: @base-color;
+            }
+        }
+    }
+}
+
+atom-text-editor.vim-mode-plus-input-char-waiting {
+    .amu-paint-cursor & {
+        &.is-focused {
+            .cursor {
+                background: none;
+                border-bottom-color: @base-color;
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Description of the Change

When "Paint text editor's cursor" option is on, `vim-mode-plus` cursor will inherit the theme's primary color as it does in the insert mode. 

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion.

-->

### Benefits

<!-- What benefits will be realized by the code change? -->

The cursor color in different modes will finally be consistent. It'll just work™

Insert Mode:
![image](https://user-images.githubusercontent.com/613647/34040622-e3b66f5a-e194-11e7-86fc-d07ae05a63c3.png)

Normal Mode:
![image](https://user-images.githubusercontent.com/613647/34040637-ee05780c-e194-11e7-9f4b-c519da80fcac.png)

Pending Operator Mode:
![image](https://user-images.githubusercontent.com/613647/34040677-0a5b5d5a-e195-11e7-8a1e-b1ee157a4e6c.png)

Surrounding Mode:
![image](https://user-images.githubusercontent.com/613647/34040690-183d2250-e195-11e7-8f67-a44e16ae4fcb.png)

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

Users who defined their own styles could potentially be impacted.

### Applicable Issues

<!-- Enter any applicable Issues here -->

#453 
